### PR TITLE
Add ability to add recipes at runtime

### DIFF
--- a/CustomEntities.cs
+++ b/CustomEntities.cs
@@ -1147,7 +1147,7 @@ namespace Oxide.Plugins
 
                     if (recipe.SaveHandling == ModifiedSaveHandling.SaveInBundleSaveList)
                     {
-                        ModifiedPrefabFullNameToCustomSaveList.Add(recipe.FullPrefabName, data.CustomEntitySaveList);
+                        ModifiedPrefabFullNameToCustomSaveList[recipe.FullPrefabName] = data.CustomEntitySaveList;
                         newCompo.AddToCustomSaveList = true;
                     }
 

--- a/CustomEntities.cs
+++ b/CustomEntities.cs
@@ -1379,9 +1379,9 @@ namespace Oxide.Plugins
 
             private static void AddToGameManifest(string fullPrefabName, GameObject newGo, bool alsoAddToCurrentEntities)
             {
-                GameManifest.pathToGuid.Add(fullPrefabName, fullPrefabName);
-                GameManifest.guidToPath.Add(fullPrefabName, fullPrefabName);
-                GameManifest.guidToObject.Add(fullPrefabName, newGo);
+                GameManifest.pathToGuid[fullPrefabName] = fullPrefabName;
+                GameManifest.guidToPath[fullPrefabName] = fullPrefabName;
+                GameManifest.guidToObject[fullPrefabName] = newGo;
 
                 if (!alsoAddToCurrentEntities)
                 {


### PR DESCRIPTION
These changes will allow registering new recipes at runtime

The problem: Right now RegisterAndLundBundle _replaces_ existing recipes, so you must include existing recipes when updating the bundle. However, this throws an exception as that recipe already exists in the game manifest. We can either check if it exists in the game manifest and skip, however, the recipe _should_ be identical to the already registered one. If it is not, then it is intentionally modified and the recipe should be updated to reflect that. 

Thus, this is why I have opted to remove .Add() and use the key instead

Usage example:

        

        static CustomPrefabBundle bundle;

        public static void RegisterBundles()
        {
            // Example if the plugin were to load a new entity after the fact
            RegisterBundle("EntityA", 1000, new Dictionary<DamageType, float>());
            RegisterBundle("EntityB", 1000, new Dictionary<DamageType, float>());

            // Example if the plugin were to update existing recipes
            RegisterBundle("EntityA", 9999, new Dictionary<DamageType, float>());
        }

        public static void RegisterBundle(string entityName, float maxHealth, Dictionary<DamageType, float> protectionProperties)
        {
            var baseCombat = new CustomEntities.CustomPrefabBaseCombat
            {
                HealthStart = maxHealth,
                HealthMax = maxHealth,
                MarkAttackerHostile = true,
                RepairEnabled = false,
                PickupEnabled = false,
                ProtectionProperties = protectionProperties
                    .OrderBy(k => k.Key)
                    .Select(v => v.Value)
                    .ToArray(),
            };

            var recipe = new CustomEntities.CustomPrefabRecipe(entityName, typeof(SomeClass), Layer.Default, baseCombat, true);
            var recipes = bundle.Recipes?.ToList() ?? new List<CustomPrefabRecipe>();
            recipes.Add(recipe);

            bundle = new CustomEntities.CustomPrefabBundle(Instance, recipes.ToArray());
            if (!CustomEntities.CustomPrefabs.RegisterAndLoadBundle(bundle))
            {
                Instance.PrintError("Bundles failed to load");
            }
        }

        public static void SaveAndUnregisterBundles()
        {
            if (bundle == null)
            {
                return;
            }

            if (!CustomEntities.CustomPrefabs.SaveAndUnregisterBundle(bundle))
            {
                Instance.PrintError("Bundles failed to unload");
            }

            bundle.Recipes = null;
            bundle = null;
        }


